### PR TITLE
Fix link and table-deletion in tutorial part 1

### DIFF
--- a/api/OEP_API_tutorial_part1.ipynb
+++ b/api/OEP_API_tutorial_part1.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "#### 3b.  Paste your token in a file\n",
     "\n",
-    "Look for the following line in the file `api/tutorials/token_config.py`,\n",
+    "Look for the following line in the file `api/token_config.py`,\n",
     "\n",
     "```python\n",
     "OEP_TOKEN = ''\n",
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +630,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The link to the config file was incorrect. I fixed this but found another issue: The example table that was supposed to be generated already existed. This tutorial contains a line that's supposed to delete it, but since I wasn't the table owner, I did not have the permissions to do so and ran into a 403 Error that wasn't explained.

Possible solutions: 
* figure out if we can change the owner to oeuser within the script, so it's always possible to delete the table
* generate a unique table name, so this error doesn't occur and delete tables every now and then
* Explain the error message and make the user choose a new table name

What do you prefer?