### PR TITLE
Relative names

### DIFF
--- a/api/OEP_API_tutorial_part1.json
+++ b/api/OEP_API_tutorial_part1.json
@@ -1,4 +1,4 @@
 {
-  "name": "https://openenergy-platform.org/tutorials/jupyter/OEP_API_tutorial_part1",
+  "name": "OEP_API_tutorial_part1",
   "displayName": "API tutorial 1 - Introduction to the OEP-API and basic table opperations"
 }

--- a/api/OEP_API_tutorial_part2.json
+++ b/api/OEP_API_tutorial_part2.json
@@ -1,4 +1,4 @@
 {
-  "name": "https://openenergy-platform.org/tutorials/jupyter/OEP_API_tutorial_part2",
+  "name": "OEP_API_tutorial_part2",
   "displayName": "API tutorial 2 - Advanced OEP-API data queries using query parameters"
 }

--- a/api/OEP_API_tutorial_part3.json
+++ b/api/OEP_API_tutorial_part3.json
@@ -1,4 +1,4 @@
 {
-  "name": "https://openenergy-platform.org/tutorials/jupyter/OEP_API_tutorial_part3",
+  "name": "OEP_API_tutorial_part3",
   "displayName": "API tutorial 3 - Plot data and spatial data"
 }

--- a/api/OEP_API_tutorial_part4.json
+++ b/api/OEP_API_tutorial_part4.json
@@ -1,4 +1,4 @@
 {
-  "name": "https://openenergy-platform.org/tutorials/jupyter/OEP_API_tutorial_part4",
+  "name": "OEP_API_tutorial_part4",
   "displayName": "API tutorial 4 - Process query result data and save to file"
 }

--- a/api/spatial-functions/OEP-oedialect_geoquery_spatial-functions.json
+++ b/api/spatial-functions/OEP-oedialect_geoquery_spatial-functions.json
@@ -1,4 +1,4 @@
 {
-    "name": "https://openenergy-platform.org/tutorials/jupyter/OEP-oedialect_geoquery_spatial-functions",
+    "name": "OEP-oedialect_geoquery_spatial-functions",
     "displayName": "Getting started with postgis spatial functions using python"
 }


### PR DESCRIPTION
This PR introduces relative names for tutorials to be able to deploy the OEP with different domain configurations. We do not want to set the URL within this repository, we only need a fixed identifier to be able to hard-link to the single tutorial within the OEP.